### PR TITLE
new command: resize selected items by aspect ratio

### DIFF
--- a/Commands/Development/Testing/TestSuite.jsf
+++ b/Commands/Development/Testing/TestSuite.jsf
@@ -445,6 +445,15 @@ test( 'Size command, single object', function(){
   assert_equal('Selected item is 1 pixel shorter', fw.selection[0].height, 110);
   orangecommands.run("Size","Height -10");
   assert_equal('Selected item is 10 pixels shorter', fw.selection[0].height, 100);
+
+  (10).times(add_rectangle);
+  fw.getDocumentDOM().selectAll();
+  orangecommands.run("Size","Scale to Fit...", "20,20");
+  fw.selection.each(function(obj) {
+      assert_equal('Selected item height is 20 pixels', obj.height, 20);
+      assert_equal('Selected item width is 20 pixels', obj.width, 20);
+  });
+
 });
 
 test( 'Size command, multiple objects', function(){

--- a/Commands/Size/Scale to Fit....jsf
+++ b/Commands/Size/Scale to Fit....jsf
@@ -1,0 +1,37 @@
+/**DOC**
+This command scales the selected elements to fit specified dimensions, preserving their aspect ratio.
+**DOC***/
+try {
+  fw.runScript(fw.appJsCommandsDir + "/bs.js");
+} catch(e){
+  alert("There was a problem running this command.\rThis is usually related to an installation problem, so please visit http://orangecommands.com and download an updated installer.\r\rSorry for the inconvenience.");
+}
+
+if (fw.selection.length > 0) {
+  var default_height = 20;
+  var default_width = 20;
+  var s = orangecommands.params || prompt("Aspect ratio (width/height):\n(You can use math operations)",default_width+","+default_height);
+
+  var final_width = s ? parseInt(s.split(",")[0], 10) : default_width;
+  var final_height = s ? parseInt(s.split(",")[1], 10) : default_height;
+  var final_ratio = final_width / final_height;
+
+  function resize(obj) {
+    var nh, nw;
+    var oh = obj.height;
+    var ow = obj.width;
+    var obj_ratio = ow / oh;
+
+    if (obj_ratio < final_ratio) {
+      nh = final_height;
+      nw = ow / (oh / nh);
+    } else {
+      nw = final_width;
+      nh = oh / (ow / nw);
+    }
+
+    obj.resize(nw, nh);
+  }
+
+  fw.selection.each(resize, false);
+}


### PR DESCRIPTION
Hi Ale!

Here my first contribution to Orange Commands :)

I needed to create a icon-font with [Font Custom](http://fontcustom.com/) so I wrote it to resize a bunch of icons preserving aspect ratio, and then export each icon to a SVG file with the [Export SVG command](http://fireworks.abeall.com/extensions/commands/Export/) modified.

See command running here http://www.screenr.com/bwZ7 
