### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -365,7 +365,7 @@ Commands to create grids using guides (the commands formerly known as "Reticulat
 
 - **Paste**  (No shortcut)
 
-  Pastes the guides copied with the "Guides » Copy" command (works accross documents!).
+  Pastes the guides copied with the "Guides » Copy" command (works across documents!).
 
 ### Layers
 


### PR DESCRIPTION
@bomberstudios, I've corrected a typographical error in the documentation of the [fireworks](https://github.com/bomberstudios/fireworks) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
